### PR TITLE
参加しているチャンネル一覧の取得・参加可能なチャンネル一覧の取得・招待可能ユーザー検索クエリの実装

### DIFF
--- a/backend/src/channel/channel.module.ts
+++ b/backend/src/channel/channel.module.ts
@@ -9,6 +9,7 @@ import { CheckChannelInvitationUseCase } from './usecases/check-channel-invitati
 import { CreateChannelUseCase } from './usecases/create-channel.usecase';
 import { GetChannelUseCase } from './usecases/get-channel.usecase';
 import { GetChannelsUseCase } from './usecases/get-channels.usecase';
+import { GetMyChannelsUseCase } from './usecases/get-my-channels.usecase';
 import { InviteToChannelUseCase } from './usecases/invite-to-channel.usecase';
 import { JoinChannelUseCase } from './usecases/join-channel.usecase';
 
@@ -27,6 +28,7 @@ import { JoinChannelUseCase } from './usecases/join-channel.usecase';
     InviteToChannelUseCase,
     JoinChannelUseCase,
     CheckChannelInvitationUseCase,
+    GetMyChannelsUseCase,
   ],
 })
 export class ChannelModule {}

--- a/backend/src/channel/channel.module.ts
+++ b/backend/src/channel/channel.module.ts
@@ -9,6 +9,7 @@ import { CheckChannelInvitationUseCase } from './usecases/check-channel-invitati
 import { CreateChannelUseCase } from './usecases/create-channel.usecase';
 import { GetChannelUseCase } from './usecases/get-channel.usecase';
 import { GetChannelsUseCase } from './usecases/get-channels.usecase';
+import { GetAvailableChannelsUseCase } from './usecases/get-available-channels.usecase';
 import { GetMyChannelsUseCase } from './usecases/get-my-channels.usecase';
 import { InviteToChannelUseCase } from './usecases/invite-to-channel.usecase';
 import { JoinChannelUseCase } from './usecases/join-channel.usecase';
@@ -29,6 +30,7 @@ import { JoinChannelUseCase } from './usecases/join-channel.usecase';
     JoinChannelUseCase,
     CheckChannelInvitationUseCase,
     GetMyChannelsUseCase,
+    GetAvailableChannelsUseCase,
   ],
 })
 export class ChannelModule {}

--- a/backend/src/channel/channel.module.ts
+++ b/backend/src/channel/channel.module.ts
@@ -4,12 +4,15 @@ import { PrismaModule } from 'src/shared/prisma/prisma.module';
 import { ChannelResolver } from './channel.resolver';
 import { ChannelDao } from './dao/channel.dao';
 import { CHANNEL_DAO_TOKEN } from './dao/channel.dao.token';
+import { ChannelUserDao } from './dao/channel-user.dao';
+import { CHANNEL_USER_DAO_TOKEN } from './dao/channel-user.dao.token';
 import { ChannelInvitationService } from './services/channel-invitation.service';
 import { CheckChannelInvitationUseCase } from './usecases/check-channel-invitation.usecase';
 import { CreateChannelUseCase } from './usecases/create-channel.usecase';
 import { GetChannelUseCase } from './usecases/get-channel.usecase';
 import { GetChannelsUseCase } from './usecases/get-channels.usecase';
 import { GetAvailableChannelsUseCase } from './usecases/get-available-channels.usecase';
+import { GetInvitableUsersUseCase } from './usecases/get-invitable-users.usecase';
 import { GetMyChannelsUseCase } from './usecases/get-my-channels.usecase';
 import { InviteToChannelUseCase } from './usecases/invite-to-channel.usecase';
 import { JoinChannelUseCase } from './usecases/join-channel.usecase';
@@ -22,6 +25,10 @@ import { JoinChannelUseCase } from './usecases/join-channel.usecase';
       provide: CHANNEL_DAO_TOKEN,
       useClass: ChannelDao,
     },
+    {
+      provide: CHANNEL_USER_DAO_TOKEN,
+      useClass: ChannelUserDao,
+    },
     ChannelInvitationService,
     CreateChannelUseCase,
     GetChannelUseCase,
@@ -31,6 +38,7 @@ import { JoinChannelUseCase } from './usecases/join-channel.usecase';
     CheckChannelInvitationUseCase,
     GetMyChannelsUseCase,
     GetAvailableChannelsUseCase,
+    GetInvitableUsersUseCase,
   ],
 })
 export class ChannelModule {}

--- a/backend/src/channel/channel.resolver.ts
+++ b/backend/src/channel/channel.resolver.ts
@@ -3,6 +3,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { User } from '@prisma/client';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { GqlAuthGuard } from 'src/auth/guards/gql-auth.guard';
+import { User as UserType } from 'src/user/graphql-types/object/user';
 import { PaginationArgs } from 'src/shared/graphql-types/args/pagination.args';
 import { CreateChannelInput } from './graphql-types/input/create-channel.input';
 import { InviteToChannelInput } from './graphql-types/input/invite-to-channel.input';
@@ -15,6 +16,7 @@ import { CreateChannelUseCase } from './usecases/create-channel.usecase';
 import { GetChannelUseCase } from './usecases/get-channel.usecase';
 import { GetChannelsUseCase } from './usecases/get-channels.usecase';
 import { GetAvailableChannelsUseCase } from './usecases/get-available-channels.usecase';
+import { GetInvitableUsersUseCase } from './usecases/get-invitable-users.usecase';
 import { GetMyChannelsUseCase } from './usecases/get-my-channels.usecase';
 import { InviteToChannelUseCase } from './usecases/invite-to-channel.usecase';
 import { JoinChannelUseCase } from './usecases/join-channel.usecase';
@@ -30,6 +32,7 @@ export class ChannelResolver {
     private readonly checkChannelInvitationUseCase: CheckChannelInvitationUseCase,
     private readonly getMyChannelsUseCase: GetMyChannelsUseCase,
     private readonly getAvailableChannelsUseCase: GetAvailableChannelsUseCase,
+    private readonly getInvitableUsersUseCase: GetInvitableUsersUseCase,
   ) {}
 
   @Mutation(() => Channel)
@@ -80,6 +83,17 @@ export class ChannelResolver {
     @CurrentUser() currentUser: User,
   ): Promise<Channel[]> {
     return this.getAvailableChannelsUseCase.execute(currentUser.id, limit, offset);
+  }
+
+  @Query(() => [UserType], { name: 'invitableUsers' })
+  @UseGuards(GqlAuthGuard)
+  async getInvitableUsers(
+    @Args('channelId', { type: () => Number }) channelId: number,
+    @Args('query', { type: () => String }) query: string,
+    @Args() { limit, offset }: PaginationArgs,
+    @CurrentUser() currentUser: User,
+  ): Promise<UserType[]> {
+    return this.getInvitableUsersUseCase.execute(channelId, currentUser.id, query, limit, offset);
   }
 
   @Query(() => Channel, { name: 'channel', nullable: true })

--- a/backend/src/channel/channel.resolver.ts
+++ b/backend/src/channel/channel.resolver.ts
@@ -13,6 +13,7 @@ import { CheckChannelInvitationUseCase } from './usecases/check-channel-invitati
 import { CreateChannelUseCase } from './usecases/create-channel.usecase';
 import { GetChannelUseCase } from './usecases/get-channel.usecase';
 import { GetChannelsUseCase } from './usecases/get-channels.usecase';
+import { GetMyChannelsUseCase } from './usecases/get-my-channels.usecase';
 import { InviteToChannelUseCase } from './usecases/invite-to-channel.usecase';
 import { JoinChannelUseCase } from './usecases/join-channel.usecase';
 
@@ -25,6 +26,7 @@ export class ChannelResolver {
     private readonly inviteToChannelUseCase: InviteToChannelUseCase,
     private readonly joinChannelUseCase: JoinChannelUseCase,
     private readonly checkChannelInvitationUseCase: CheckChannelInvitationUseCase,
+    private readonly getMyChannelsUseCase: GetMyChannelsUseCase,
   ) {}
 
   @Mutation(() => Channel)
@@ -57,6 +59,14 @@ export class ChannelResolver {
   @Query(() => [Channel], { name: 'channels' })
   async getChannels(): Promise<Channel[]> {
     return this.getChannelsUseCase.execute();
+  }
+
+  @Query(() => [Channel], { name: 'myChannels' })
+  @UseGuards(GqlAuthGuard)
+  async getMyChannels(
+    @CurrentUser() currentUser: User,
+  ): Promise<Channel[]> {
+    return this.getMyChannelsUseCase.execute(currentUser.id);
   }
 
   @Query(() => Channel, { name: 'channel', nullable: true })

--- a/backend/src/channel/channel.resolver.ts
+++ b/backend/src/channel/channel.resolver.ts
@@ -3,6 +3,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { User } from '@prisma/client';
 import { CurrentUser } from 'src/auth/decorators/current-user.decorator';
 import { GqlAuthGuard } from 'src/auth/guards/gql-auth.guard';
+import { PaginationArgs } from 'src/shared/graphql-types/args/pagination.args';
 import { CreateChannelInput } from './graphql-types/input/create-channel.input';
 import { InviteToChannelInput } from './graphql-types/input/invite-to-channel.input';
 import { JoinChannelInput } from './graphql-types/input/join-channel.input';
@@ -13,6 +14,7 @@ import { CheckChannelInvitationUseCase } from './usecases/check-channel-invitati
 import { CreateChannelUseCase } from './usecases/create-channel.usecase';
 import { GetChannelUseCase } from './usecases/get-channel.usecase';
 import { GetChannelsUseCase } from './usecases/get-channels.usecase';
+import { GetAvailableChannelsUseCase } from './usecases/get-available-channels.usecase';
 import { GetMyChannelsUseCase } from './usecases/get-my-channels.usecase';
 import { InviteToChannelUseCase } from './usecases/invite-to-channel.usecase';
 import { JoinChannelUseCase } from './usecases/join-channel.usecase';
@@ -27,6 +29,7 @@ export class ChannelResolver {
     private readonly joinChannelUseCase: JoinChannelUseCase,
     private readonly checkChannelInvitationUseCase: CheckChannelInvitationUseCase,
     private readonly getMyChannelsUseCase: GetMyChannelsUseCase,
+    private readonly getAvailableChannelsUseCase: GetAvailableChannelsUseCase,
   ) {}
 
   @Mutation(() => Channel)
@@ -64,9 +67,19 @@ export class ChannelResolver {
   @Query(() => [Channel], { name: 'myChannels' })
   @UseGuards(GqlAuthGuard)
   async getMyChannels(
+    @Args() { limit, offset }: PaginationArgs,
     @CurrentUser() currentUser: User,
   ): Promise<Channel[]> {
-    return this.getMyChannelsUseCase.execute(currentUser.id);
+    return this.getMyChannelsUseCase.execute(currentUser.id, limit, offset);
+  }
+
+  @Query(() => [Channel], { name: 'availableChannels' })
+  @UseGuards(GqlAuthGuard)
+  async getAvailableChannels(
+    @Args() { limit, offset }: PaginationArgs,
+    @CurrentUser() currentUser: User,
+  ): Promise<Channel[]> {
+    return this.getAvailableChannelsUseCase.execute(currentUser.id, limit, offset);
   }
 
   @Query(() => Channel, { name: 'channel', nullable: true })

--- a/backend/src/channel/dao/channel-user.dao.interface.ts
+++ b/backend/src/channel/dao/channel-user.dao.interface.ts
@@ -1,0 +1,6 @@
+import { User } from "@prisma/client";
+
+export interface IChannelUserDao {
+  isChannelMember(channelId: number, userId: number): Promise<boolean>;
+  findInvitableUsersByChannelId(channelId: number, query: string, limit: number, offset: number): Promise<User[]>;
+}

--- a/backend/src/channel/dao/channel-user.dao.token.ts
+++ b/backend/src/channel/dao/channel-user.dao.token.ts
@@ -1,0 +1,1 @@
+export const CHANNEL_USER_DAO_TOKEN = Symbol('ChannelUserDao');

--- a/backend/src/channel/dao/channel-user.dao.ts
+++ b/backend/src/channel/dao/channel-user.dao.ts
@@ -1,0 +1,48 @@
+import { Injectable } from "@nestjs/common";
+import { User } from "@prisma/client";
+import { PrismaService } from "src/shared/prisma/prisma.service";
+import { IChannelUserDao } from "./channel-user.dao.interface";
+
+@Injectable()
+export class ChannelUserDao implements IChannelUserDao {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async isChannelMember(channelId: number, userId: number): Promise<boolean> {
+    const channelUser = await this.prismaService.channelUser.findFirst({
+      where: {
+        channelId,
+        userId,
+        deletedAt: null,
+      },
+    });
+    return channelUser !== null;
+  }
+
+  async findInvitableUsersByChannelId(
+    channelId: number,
+    query: string,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<User[]> {
+    return this.prismaService.user.findMany({
+      where: {
+        deletedAt: null,
+        channels: {
+          none: {
+            channelId, // すでにチャンネルに参加しているユーザーは除外（自分自身も含む）
+            deletedAt: null,
+          },
+        },
+        OR: [ // 名前またはメールアドレスにクエリが部分一致するユーザーを検索
+          { name: { contains: query, mode: "insensitive" } },
+          { email: { contains: query, mode: "insensitive" } },
+        ],
+      },
+      orderBy: {
+        name: "asc",
+      },
+      take: limit,
+      skip: offset,
+    });
+  }
+}

--- a/backend/src/channel/dao/channel.dao.interface.ts
+++ b/backend/src/channel/dao/channel.dao.interface.ts
@@ -15,5 +15,7 @@ export interface IChannelDao {
 
   inviteUsersToChannel(channelId: number, userIds: number[]): Promise<void>;
 
-  findChannelsByUserId(userId: number): Promise<Channel[]>;
+  findChannelsByUserId(userId: number, limit: number, offset: number): Promise<Channel[]>;
+
+  findAvailableChannelsByUserId(userId: number, limit: number, offset: number): Promise<Channel[]>;
 }

--- a/backend/src/channel/dao/channel.dao.interface.ts
+++ b/backend/src/channel/dao/channel.dao.interface.ts
@@ -14,4 +14,6 @@ export interface IChannelDao {
   findChannelUserIdsByChannelId(channelId: number): Promise<number[]>;
 
   inviteUsersToChannel(channelId: number, userIds: number[]): Promise<void>;
+
+  findChannelsByUserId(userId: number): Promise<Channel[]>;
 }

--- a/backend/src/channel/dao/channel.dao.ts
+++ b/backend/src/channel/dao/channel.dao.ts
@@ -92,4 +92,21 @@ export class ChannelDao implements IChannelDao {
       })),
     });
   }
+
+  async findChannelsByUserId(userId: number): Promise<Channel[]> {
+    return this.prismaService.channel.findMany({
+      where: {
+        deletedAt: null,
+        users: { // channelUserのリレーションから取得
+          some: {
+            userId,
+            deletedAt: null,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+    });
+  }
 }

--- a/backend/src/channel/dao/channel.dao.ts
+++ b/backend/src/channel/dao/channel.dao.ts
@@ -93,7 +93,34 @@ export class ChannelDao implements IChannelDao {
     });
   }
 
-  async findChannelsByUserId(userId: number): Promise<Channel[]> {
+  async findAvailableChannelsByUserId(
+    userId: number,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<Channel[]> {
+    return this.prismaService.channel.findMany({
+      where: {
+        deletedAt: null,
+        users: {
+          none: {
+            userId,
+            deletedAt: null,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+      take: limit,
+      skip: offset,
+    });
+  }
+
+  async findChannelsByUserId(
+    userId: number,
+    limit: number = 50,
+    offset: number = 0,
+  ): Promise<Channel[]> {
     return this.prismaService.channel.findMany({
       where: {
         deletedAt: null,
@@ -107,6 +134,8 @@ export class ChannelDao implements IChannelDao {
       orderBy: {
         createdAt: "asc",
       },
+      take: limit,
+      skip: offset,
     });
   }
 }

--- a/backend/src/channel/usecases/get-available-channels.usecase.ts
+++ b/backend/src/channel/usecases/get-available-channels.usecase.ts
@@ -4,10 +4,10 @@ import { CHANNEL_DAO_TOKEN } from "../dao/channel.dao.token";
 import { Channel } from "../graphql-types/object/channel";
 
 @Injectable()
-export class GetMyChannelsUseCase {
+export class GetAvailableChannelsUseCase {
   constructor(@Inject(CHANNEL_DAO_TOKEN) private readonly channelDao: IChannelDao) {}
 
   async execute(userId: number, limit: number = 50, offset: number = 0): Promise<Channel[]> {
-    return this.channelDao.findChannelsByUserId(userId, limit, offset);
+    return this.channelDao.findAvailableChannelsByUserId(userId, limit, offset);
   }
 }

--- a/backend/src/channel/usecases/get-invitable-users.usecase.ts
+++ b/backend/src/channel/usecases/get-invitable-users.usecase.ts
@@ -1,0 +1,28 @@
+import { Injectable, Inject, ForbiddenException, NotFoundException } from "@nestjs/common";
+import { User } from "@prisma/client";
+import { IChannelDao } from "../dao/channel.dao.interface";
+import { CHANNEL_DAO_TOKEN } from "../dao/channel.dao.token";
+import { IChannelUserDao } from "../dao/channel-user.dao.interface";
+import { CHANNEL_USER_DAO_TOKEN } from "../dao/channel-user.dao.token";
+
+@Injectable()
+export class GetInvitableUsersUseCase {
+  constructor(
+    @Inject(CHANNEL_DAO_TOKEN) private readonly channelDao: IChannelDao,
+    @Inject(CHANNEL_USER_DAO_TOKEN) private readonly channelUserDao: IChannelUserDao,
+  ) {}
+
+  async execute(channelId: number, userId: number, query: string, limit: number = 50, offset: number = 0): Promise<User[]> {
+    const channel = await this.channelDao.findChannelById(channelId);
+    if (!channel) {
+      throw new NotFoundException("指定のチャンネルが見つかりません");
+    }
+
+    const isMember = await this.channelUserDao.isChannelMember(channelId, userId);
+    if (!isMember) {
+      throw new ForbiddenException("参加しているチャンネルのメンバーのみ招待可能ユーザーを検索できます");
+    }
+
+    return this.channelUserDao.findInvitableUsersByChannelId(channelId, query, limit, offset);
+  }
+}

--- a/backend/src/channel/usecases/get-my-channels.usecase.ts
+++ b/backend/src/channel/usecases/get-my-channels.usecase.ts
@@ -1,0 +1,13 @@
+import { Injectable, Inject } from "@nestjs/common";
+import { IChannelDao } from "../dao/channel.dao.interface";
+import { CHANNEL_DAO_TOKEN } from "../dao/channel.dao.token";
+import { Channel } from "../graphql-types/object/channel";
+
+@Injectable()
+export class GetMyChannelsUseCase {
+  constructor(@Inject(CHANNEL_DAO_TOKEN) private readonly channelDao: IChannelDao) {}
+
+  async execute(userId: number): Promise<Channel[]> {
+    return this.channelDao.findChannelsByUserId(userId);
+  }
+}


### PR DESCRIPTION
## 概要

この前設計した、チャンネル関連のクエリを実装しました。
別で招待ユーザー検索用のクエリを追加しています。

---

## 機能一覧

| 種別 | エンドポイント | 説明 |
|------|---------------|------|
| Query | `myChannels` | 自分が参加しているチャンネル一覧を取得 |
| Query | `availableChannels` | 自分が未参加のチャンネル一覧を取得 |
| Query | `invitableUsers` | チャンネルに招待可能なユーザーを検索 |

---

## 機能詳細
### myChannels / availableChannels
- `myChannels` 自分が参加しているチャンネル一覧を取得
- `availableChannels` 自分が未参加のチャンネル一覧を取得（参加可能なチャンネル）
- どちらも `limit` / `offset` によるページネーションに対応（デフォルト: limit=50, offset=0）

### invitableUsers
- チャンネルIDと検索クエリを指定して、招待可能なユーザーを検索
- ユーザー名・メールアドレスの部分一致（大文字小文字区別なし）で検索
- チャンネルメンバー（自分自身含む）は自動的に除外
- リクエスト元ユーザーがチャンネルメンバーでない場合は403エラー
- `limit` / `offset` によるページネーションに対応

---

## GraphQL Playground テスト用クエリ

参加チャンネル一覧（myChannels）
```graphql
query MyChannels {
  myChannels(limit: 10, offset: 0) {
    id
    name
  }
}
未参加チャンネル一覧（availableChannels）

query AvailableChannels {
  availableChannels(limit: 10, offset: 0) {
    id
    name
  }
}
招待可能ユーザー検索（invitableUsers）

query InvitableUsers {
  invitableUsers(channelId: 1, query: "田中", limit: 10, offset: 0) {
    id
    name
    email
  }
}
```